### PR TITLE
refactor rx retrieve for better maintainability

### DIFF
--- a/server/titles/streams/titles.controller.js
+++ b/server/titles/streams/titles.controller.js
@@ -1,14 +1,21 @@
 'use strict';
 const titlesService = require('./titles.service');
+const titleHelpers = require('../titles.helpers');
 
 /*
  * Controller function returns titles for provided addresses
  */
 function retrieve(req, res, next) {
-  titlesService.retrieve(req.query.address)
-    .subscribe(
-      html => res.status(200).send(html),
-      err => next(err));
+  return titlesService.retrieve(req.query.address)
+    .toArray() /* returns Observable containing one emission with all values in an array */
+    .toPromise() /* express knows how to handle promises and thus we return a promise. toPromise() also makes your observable hot */
+    .then(addresses => {
+      const html = titleHelpers.renderHtml(addresses);
+      res.status(200).send(html);
+    })
+    .catch(err => {
+        next(err);
+    });
 }
 
 exports.retrieve = retrieve;

--- a/server/titles/streams/titles.service.js
+++ b/server/titles/streams/titles.service.js
@@ -33,6 +33,7 @@ function retrieve(addresses) {
       (address, title) => {
         // no modification of global state (array), just emit the data objects as they become available
         return {
+          originalUri: address.originalUri,
           normalizedUri: address.normalizedUri,
           title: title
         };


### PR DESCRIPTION
Hi!

I wanted to give you feedback on your `retrieve()` function but thought it was the easiest by providing you with this PR. 

The biggest changes are:
- Not using `Subject` unless you know what you are doing (rule of thumb: if you think you need them you are probably wrong).
- Decouple construction of Observable stream from lifecycle/subscribe
- Remove state modification (`addresses` array) from Rx stream

Note; i'm usually using Rxjs 4.x and i know that they have not implemented all operators and renamed a few in 5.x. This PR might not 100% run due to this.